### PR TITLE
Testing m

### DIFF
--- a/frontend/src/pages/EditProfilePage.tsx
+++ b/frontend/src/pages/EditProfilePage.tsx
@@ -254,14 +254,14 @@ async function handleChangePassword(e: React.FormEvent) {
 
   if (isProfileLoading) {
     return (
-      <div className="h-[calc(100dvh-250px)] bg-bg px-4 py-8">
+      <div className="min-h-[calc(100dvh-250px)] bg-bg px-4 py-8 pb-32">
         <div className="mx-auto max-w-3xl text-text">Loading profile...</div>
       </div>
     )
   }
 
   return (
-    <div className="h-[calc(100dvh-250px)] bg-bg px-4 py-8">
+    <div className="min-h-[calc(100dvh-250px)] bg-bg px-4 py-8 pb-32">
       <div className="mx-auto flex max-w-3xl flex-col gap-6">
         {/* {Form with Bio, Name, Username, AvatarUrl && and includes close x with Edit header} */}
         <form


### PR DESCRIPTION
The container used h-[calc(100dvh-250px)] with no overflow rule, so
the two stacked forms got clipped by the fixed BottomNav and the
"Change Password" submit button was unreachable.

Switch to min-h-[calc(100dvh-250px)] so the container grows with
its content and uses page-level scroll, and add pb-32 so the last
button clears the BottomNav. Apply the same min-h to the loading
state for consistency.